### PR TITLE
Fix running out of entries in `charorder`

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -161,12 +161,14 @@ function revelation.expose(args)
     for i,thisclient in pairs(clientlist) do 
         -- Move wiboxes to center of visible windows and populate hintindex
         local char = charorder:sub(i,i)
-        hintindex[char] = thisclient
-        local geom = thisclient.geometry(thisclient)
-        hintbox[char].visible = true
-        hintbox[char].x = geom.x + geom.width/2 - hintsize/2
-        hintbox[char].y = geom.y + geom.height/2 - hintsize/2
-        hintbox[char].screen = thisclient.screen
+        if char and char ~= '' then
+            hintindex[char] = thisclient
+            local geom = thisclient.geometry(thisclient)
+            hintbox[char].visible = true
+            hintbox[char].x = geom.x + geom.width/2 - hintsize/2
+            hintbox[char].y = geom.y + geom.height/2 - hintsize/2
+            hintbox[char].screen = thisclient.screen
+        end
     end
 
     local function restore()


### PR DESCRIPTION
When there are more clients than entries in `charorder`, the following
error occurs:

    W: awesome: luaA_dofunction:77: error while running function
    stack traceback:
            /home/user/.config/awesome/revelation/init.lua:166: in function </home/user/.config/awesome/revelation/init.lua:124>
            (...tail calls...)
            /usr/local/share/awesome/lib/awful/key.lua:43: in function </usr/local/share/awesome/lib/awful/key.lua:43>
    error: /home/user/.config/awesome/revelation/init.lua:166: attempt to index field '?' (a nil value)

This fixes it by skipping setup of `hintindex` in this case.