### PR TITLE
Added an option to change character ordering for selecting clients.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ It also have some features.
 ~~For current stable version of awesome, 3.5.6, please checkout stable version~~
 
 ## Changes since 2014-02-19
-## Changes since 2014-02-19
 * Now the revlation is able to handle the special clients(float, fullscreen or maximized etc.)
 * When you select an minimized client, the revelation will un-minimized it and then focuse on it.
+* Added an option to change character ordering
 
 ## Changes after 2013-12-30
 * Now it is possible, in revelation.init({...}), to change the default settings of 
@@ -95,7 +95,7 @@ is_excluded=true})`.
 ### Configuration
  Revelation's configuration is done through the init() function
  
- There are two basic settings, shown with default values:
+ There are three basic settings, shown with default values:
 
     -- The name of the tag created for the 'exposed' view
     revelation.tag_name = 'Revelation'
@@ -104,6 +104,9 @@ is_excluded=true})`.
     revelation.exact = awful.rules.match
     revelation.any   = awful.rules.match_any
 
+    -- Character order for selecting clients
+    revelation.charorder = "jkluiopyhnmfdsatgvcewqzx1234567890",
+
  The rule matching functions must conform to `awful.rules.match` prototypes.
 
  For client matching rules, we follow the same syntax as awful.rules expects.
@@ -111,7 +114,7 @@ is_excluded=true})`.
 
 to change the settings, use:
 
-     revelation.init({tag_name = ..., match={...})
+     revelation.init({tag_name = ..., match = {...}, charorder = ...)
 
 
 ### Examples

--- a/init.lua
+++ b/init.lua
@@ -34,12 +34,13 @@ local delayed_call = (type(timer) ~= 'table' and  require("gears.timer").delayed
 
 local clientData = {} -- table that holds the positions and sizes of floating clients
 
-local charorder = "jkluiopyhnmfdsatgvcewqzx1234567890"
 local hintbox = {} -- Table of letter wiboxes with characters as the keys
 
 local revelation = {
     -- Name of expose tag.
     tag_name = "Revelation",
+
+    charorder = "jkluiopyhnmfdsatgvcewqzx1234567890",
 
     -- Match function can be defined by user.
     -- Must accept a `rule` and `client` and return `boolean`.
@@ -169,7 +170,7 @@ function revelation.expose_callback(t, zt)
     local clientlist = awful.client.visible()
     for i,thisclient in pairs(clientlist) do
         -- Move wiboxes to center of visible windows and populate hintindex
-        local char = charorder:sub(i,i)
+        local char = revelation.charorder:sub(i,i)
         if char and char ~= '' then
             hintindex[char] = thisclient
             local geom = thisclient:geometry()
@@ -337,9 +338,10 @@ function revelation.init(args)
         revelation.match.any = args.match.any or revelation.match.any
     end
 
+    revelation.charorder = args.charorder or revelation.charorder
 
-    for i = 1, #charorder do
-        local char = charorder:sub(i,i)
+    for i = 1, #revelation.charorder do
+        local char = revelation.charorder:sub(i,i)
         hintbox[char] = wibox({fg=beautiful.fg_normal, bg=beautiful.bg_focus, border_color=beautiful.border_focus, border_width=beautiful.border_width})
         hintbox[char].ontop = true
         hintbox[char].width = revelation.hintsize


### PR DESCRIPTION
It could be useful for users with different keyboard layouts e.g dvorak.
To change to different settings, use:

     revelation.init(charorder = "htngcrlfdbmueoayikj.,';q1234567890")