### PR TITLE
Do not set module settings from function args

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -157,11 +157,8 @@ end
 function revelation.expose(args)
     args = args or {}
     local rule = args.rule or {}
-    local is_excluded = args.is_excluded or false
-    local curr_tag_only = args.curr_tag_only or false
-
-    revelation.is_excluded = is_excluded
-    revelation.curr_tag_only = curr_tag_only
+    local is_excluded = args.is_excluded or revelation.is_excluded
+    local curr_tag_only = args.curr_tag_only or revelation.curr_tag_only
 
     local t={}
     local zt={}


### PR DESCRIPTION
It seems more sensible to use the module settings as default, but not
set them to the given values.